### PR TITLE
Separated summary statistics from distance and provided some built-in summary statistics

### DIFF
--- a/src/GpAbc.jl
+++ b/src/GpAbc.jl
@@ -51,6 +51,7 @@ include("util/latin_hypercube_sampler.jl")
 include("abc/io.jl")
 include("abc/rejection.jl")
 include("abc/smc.jl")
+include("abc/summary_stats.jl")
 
 
 # include("abc.jl")

--- a/src/abc/io.jl
+++ b/src/abc/io.jl
@@ -5,15 +5,14 @@ abstract type ABCInput end
 
 abstract type ABCRejectionInput <: ABCInput end
 
-abstract type ABCSMCInput <: ABCInput end
-
 struct SimulatedABCRejectionInput <: ABCRejectionInput
     n_params::Int64
     n_particles::Int64
     threshold::Float64
     priors::Vector{ContinuousUnivariateDistribution}
+    summary_statistic::Union{String,Vector{String},Function}
     distance_function::Function
-    data_generating_function::Function
+    simulator_function::Function
 end
 
 struct EmulatedABCRejectionInput <: ABCRejectionInput
@@ -26,13 +25,16 @@ struct EmulatedABCRejectionInput <: ABCRejectionInput
     max_iter::Int
 end
 
+abstract type ABCSMCInput <: ABCInput end
+
 struct SimulatedABCSMCInput <: ABCSMCInput
     n_params::Int64
     n_particles::Int64
     threshold_schedule::Vector{Float64}
     priors::Vector{ContinuousUnivariateDistribution}
+    summary_statistic::Union{String,Vector{String},Function}
     distance_function::Function
-    data_generating_function::Function
+    simulator_function::Function
 end
 
 struct EmulatedABCSMCInput <: ABCSMCInput
@@ -59,8 +61,9 @@ mutable struct SimulatedABCSMCTracker <: ABCSMCTracker
     distances::Vector{Vector{Float64}}
     weights::Vector{StatsBase.Weights}
     priors::Vector{ContinuousUnivariateDistribution}
+    summary_statistic::Function
     distance_function::Function
-    data_generating_function::Function
+    simulator_function::Function
 end
 
 mutable struct EmulatedABCSMCTracker <: ABCSMCTracker
@@ -74,7 +77,6 @@ mutable struct EmulatedABCSMCTracker <: ABCSMCTracker
     priors::Vector{ContinuousUnivariateDistribution}
     distance_prediction_function::Function
 end
-
 
 #
 # Output types

--- a/src/abc/rejection.jl
+++ b/src/abc/rejection.jl
@@ -44,7 +44,7 @@ end
 #
 # Note - have removed simulation_args... should pass an anonymous function that returns
 # simulation results with the parameters as the only argument to SimulatedABCRejectionInput
-# as data_generating_function
+# as simulator_function
 #
 
 #
@@ -66,11 +66,16 @@ function ABCrejection(
     accepted_distances = zeros(input.n_particles)
     weights = ones(input.n_particles)
 
+    # Summary statistic initialisation
+    summary_statistic = build_summary_statistic(input.summary_statistic)
+    reference_data_sum_stat = summary_statistic(reference_data)
+
     # simulate
     while n_accepted < input.n_particles
         parameters, weight = generate_parameters(input.priors)
-        simulated_data = input.data_generating_function(parameters)
-        distance = input.distance_function(reference_data, simulated_data)
+        simulated_data = input.simulator_function(parameters)
+        simulated_data_sum_stat = summary_statistic(simulated_data)
+        distance = input.distance_function(reference_data_sum_stat, simulated_data_sum_stat)
         n_tries += 1
 
         if distance <= input.threshold

--- a/src/abc/summary_stats.jl
+++ b/src/abc/summary_stats.jl
@@ -10,7 +10,7 @@ function build_summary_statistic(summary_statistic_string::String)
     elseif summary_statistic_string == "keep_all"
         return keep_all_summary_statistic
     else
-        error("$(summary_statistic) is not a valid summary statistic")
+        error("$(summary_statistic_string) is not a valid summary statistic")
     end
 
 end

--- a/src/abc/summary_stats.jl
+++ b/src/abc/summary_stats.jl
@@ -1,0 +1,59 @@
+#
+# Create functions if a string is passed as summary_statistic
+#
+function build_summary_statistic(summary_statistic_string::String)
+
+    if summary_statistic_string == "mean"
+        return mean_summary_statistic
+    elseif summary_statistic_string == "variance"
+        return var_summary_statistic
+    elseif summary_statistic_string == "keep_all"
+        return keep_all_summary_statistic
+    else
+        error("$(summary_statistic) is not a valid summary statistic")
+    end
+
+end
+
+function build_summary_statistic(summary_statistic_strings::Vector{String})
+    function summary_statistic(data)
+        sum_stat_funcs = [build_summary_statistic(sum_stat) for sum_stat in summary_statistic_strings]
+        out = [func(data) for func in sum_stat_funcs]
+        return vcat(out...)
+    end
+    return summary_statistic
+end
+
+#
+# Check a user-defined summary statistic function
+#
+function build_summary_statistic(summary_statistic_func::Function)
+    # Check output shape is right
+    test_output = summary_statistic_func(rand(3,100))
+
+    if ndims(test_output) != 1
+        error("The summary statistic function provided does not return a 1D array")
+    end
+
+    return summary_statistic_func
+end
+
+#
+# Built-in summary statistics. Data should be in the format returned by
+# DifferentialEquations.solve i.e. an array with size (n_trajectories, n_time_points)
+#
+
+# Mean of each trajectory
+function mean_summary_statistic(data::AbstractArray{Float64,2})
+    return mean(data, 2)[:]
+end
+
+# Variance of each trajectory
+function var_summary_statistic(data::AbstractArray{Float64,2})
+    return var(data, 2)[:]
+end
+
+# Keep all the data from all the trajectoriess
+function keep_all_summary_statistic(data::AbstractArray{Float64,2})
+    return reshape(data, prod(size(data)))
+end

--- a/src/gp/gp.jl
+++ b/src/gp/gp.jl
@@ -22,7 +22,7 @@ abstract type AbstractGaussianProcess end;
 """
     GPModel
 
-The main type that is used by most functions withing the package.
+The main type that is used by most functions within the package.
 
 All data matrices are row-major.
 

--- a/test/abc/rejection-abc-test.jl
+++ b/test/abc/rejection-abc-test.jl
@@ -6,7 +6,6 @@ using Base.Test, GpAbc, DifferentialEquations, Distances, Distributions
     #
     n_var_params = 2
     n_particles = 1000
-    threshold = 0.5
     priors = [Uniform(0., 5.), Uniform(0., 5.)]
     distance_metric = euclidean
     progress_every = 1000
@@ -57,11 +56,45 @@ using Base.Test, GpAbc, DifferentialEquations, Distances, Distributions
     reference_data = GeneReg(true_params, Tspan, x0, solver, saveat)
     simulator_function(var_params) = GeneReg(vcat(var_params, true_params[n_var_params+1:end]), Tspan, x0, solver, saveat)
 
+    #
+    # Test using keep all as summary statistic
+    #
     sim_rej_input = SimulatedABCRejectionInput(n_var_params,
                             n_particles,
-                            threshold,
+                            0.5,
                             priors,
                             "keep_all",
+                            distance_metric,
+                            simulator_function)
+
+    sim_result = ABCrejection(sim_rej_input, reference_data, write_progress=false)
+    @test size(sim_result.population, 1) > 0
+
+    #
+    # Test using mean and variance as summary statistic
+    #
+    sim_rej_input = SimulatedABCRejectionInput(n_var_params,
+                            n_particles,
+                            3.0,
+                            priors,
+                            ["mean", "variance"],
+                            distance_metric,
+                            simulator_function)
+
+    sim_result = ABCrejection(sim_rej_input, reference_data, write_progress=false)
+    @test size(sim_result.population, 1) > 0
+
+    #
+    # Test using custom summary statistic
+    #
+    function sum_stat(data::AbstractArray{Float64,2})
+        return std(data, 2)[:]
+    end
+    sim_rej_input = SimulatedABCRejectionInput(n_var_params,
+                            n_particles,
+                            3.0,
+                            priors,
+                            sum_stat,
                             distance_metric,
                             simulator_function)
 
@@ -101,7 +134,7 @@ using Base.Test, GpAbc, DifferentialEquations, Distances, Distributions
 
     emu_rej_input = EmulatedABCRejectionInput(n_var_params,
           n_particles,
-          threshold,
+          0.5,
           priors,
           predict_distance,
           batch_size,

--- a/test/abc/rejection-abc-test.jl
+++ b/test/abc/rejection-abc-test.jl
@@ -61,6 +61,7 @@ using Base.Test, GpAbc, DifferentialEquations, Distances, Distributions
                             n_particles,
                             threshold,
                             priors,
+                            "keep_all",
                             distance_metric,
                             simulator_function)
 
@@ -72,12 +73,17 @@ using Base.Test, GpAbc, DifferentialEquations, Distances, Distributions
         simulator_function, distance_metric,
         reference_data)
 
-        X = zeros(n_design_points, length(priors))
+        n_var_params = length(priors)
+
+        X = zeros(n_design_points, n_var_params)
         y = zeros(n_design_points)
+
+        for j in 1:n_var_params
+            X[:,j] = rand(priors[j], n_design_points)
+        end
+
         for i in 1:n_design_points
-            dp = [rand(d) for d in priors]
-            X[i,:] = dp
-            y[i] = distance_metric(simulator_function(dp), reference_data)
+            y[i] = distance_metric(simulator_function(X[i,:]), reference_data)
         end
 
         return X, y

--- a/test/abc/smc-abc-test.jl
+++ b/test/abc/smc-abc-test.jl
@@ -57,11 +57,45 @@ using Base.Test, GpAbc, DifferentialEquations, Distances, Distributions
     reference_data = GeneReg(true_params, Tspan, x0, solver, saveat)
     simulator_function(var_params) = GeneReg(vcat(var_params, true_params[n_var_params+1:end]), Tspan, x0, solver, saveat)
 
+    #
+    # Test using keep all as summary statistic
+    #
     sim_abcsmc_input = SimulatedABCSMCInput(n_var_params,
         n_particles,
         threshold_schedule,
         priors,
         "keep_all",
+        distance_metric,
+        simulator_function)
+
+    sim_abcsmc_res = ABCSMC(sim_abcsmc_input, reference_data, write_progress = false)
+    @test size(sim_abcsmc_res.population, 1) > 0
+
+    #
+    # Test using mean and variance as summary statistic
+    #
+    sim_abcsmc_input = SimulatedABCSMCInput(n_var_params,
+        n_particles,
+        3.0 * threshold_schedule,
+        priors,
+        ["mean", "variance"],
+        distance_metric,
+        simulator_function)
+
+    sim_abcsmc_res = ABCSMC(sim_abcsmc_input, reference_data, write_progress = false)
+    @test size(sim_abcsmc_res.population, 1) > 0
+
+    #
+    # Test using custom summary statistic
+    #
+    function sum_stat(data::AbstractArray{Float64,2})
+        return std(data, 2)[:]
+    end
+    sim_abcsmc_input = SimulatedABCSMCInput(n_var_params,
+        n_particles,
+        3.0 * threshold_schedule,
+        priors,
+        sum_stat,
         distance_metric,
         simulator_function)
 

--- a/test/abc/smc-abc-test.jl
+++ b/test/abc/smc-abc-test.jl
@@ -61,6 +61,7 @@ using Base.Test, GpAbc, DifferentialEquations, Distances, Distributions
         n_particles,
         threshold_schedule,
         priors,
+        "keep_all",
         distance_metric,
         simulator_function)
 
@@ -72,12 +73,17 @@ using Base.Test, GpAbc, DifferentialEquations, Distances, Distributions
         simulator_function, distance_metric,
         reference_data)
 
-        X = zeros(n_design_points, length(priors))
+        n_var_params = length(priors)
+
+        X = zeros(n_design_points, n_var_params)
         y = zeros(n_design_points)
+        
+        for j in 1:n_var_params
+            X[:,j] = rand(priors[j], n_design_points)
+        end
+
         for i in 1:n_design_points
-            dp = [rand(d) for d in priors]
-            X[i,:] = dp
-            y[i] = distance_metric(simulator_function(dp), reference_data)
+            y[i] = distance_metric(simulator_function(X[i,:]), reference_data)
         end
 
         return X, y


### PR DESCRIPTION
For simulation-based rejection- and SMC-ABC, the summary statistic is now separated from the distance function. 

Some basic summary statistics are provided that can be specified using strings, or the user can supply a summary statistic function.

Also changed name of `data_generating_function` to `simulator_function`.