### PR TITLE
Made Generic DistanceInput type to allow for non-1d summary statistics

### DIFF
--- a/src/abc/io.jl
+++ b/src/abc/io.jl
@@ -5,10 +5,15 @@ abstract type ABCInput end
 
 abstract type ABCRejectionInput <: ABCInput end
 
+
 RepetitiveTraining(; rt_iterations::Int64=0, rt_extra_training_points::Int64=1, rt_sample_size::Int64=1000) =
     RepetitiveTraining(rt_iterations, rt_extra_training_points, rt_sample_size)
 
-struct DistanceSimulationInput
+# DistanceInput must have the same fields as DistanceSimulationInput, but not necessarily the same types
+# This allows for summary statistics which are not 1D
+abstract type DistanceInput end
+
+struct DistanceSimulationInput <: DistanceInput
     reference_summary_statistic::AbstractArray{Float64,1}
     simulator_function::Function
     summary_statistic::Function
@@ -98,13 +103,13 @@ end
 DefaultEmulatorTraining() = DefaultEmulatorTraining(SquaredExponentialArdKernel())
 
 struct EmulatorTrainingInput{ET<:AbstractEmulatorTraining}
-    distance_simulation_input::DistanceSimulationInput
+    distance_simulation_input::DistanceInput
     design_points::Int64
     emulator_training::ET
 end
-EmulatorTrainingInput(dsi::DistanceSimulationInput) = EmulatorTrainingInput(dsi, DefaultEmulatorTraining())
+EmulatorTrainingInput(dsi::DistanceInput) = EmulatorTrainingInput(dsi, DefaultEmulatorTraining())
 EmulatorTrainingInput(n_design_points, reference_summary_statistic, simulator_function, summary_statistic, distance_metric, et=DefaultEmulatorTraining()) =
-    EmulatorTrainingInput(DistanceSimulationInput(
+    EmulatorTrainingInput(DistanceInput(
         reference_summary_statistic, simulator_function,
         build_summary_statistic(summary_statistic), distance_metric),
         n_design_points, et)
@@ -176,7 +181,7 @@ struct SimulatedABCRejectionInput <: ABCRejectionInput
     n_particles::Int64
     threshold::Float64
     priors::AbstractArray{ContinuousUnivariateDistribution,1}
-    distance_simulation_input::DistanceSimulationInput
+    distance_simulation_input::DistanceInput
     max_iter::Int
 end
 
@@ -198,7 +203,7 @@ struct SimulatedABCSMCInput <: ABCSMCInput
     n_particles::Int64
     threshold_schedule::AbstractArray{Float64,1}
     priors::AbstractArray{ContinuousUnivariateDistribution,1}
-    distance_simulation_input::DistanceSimulationInput
+    distance_simulation_input::DistanceInput
     max_iter::Int
 end
 
@@ -238,7 +243,7 @@ mutable struct SimulatedABCSMCTracker <: ABCSMCTracker
     distances::AbstractArray{AbstractArray{Float64,1},1}
     weights::AbstractArray{StatsBase.Weights,1}
     priors::AbstractArray{ContinuousUnivariateDistribution,1}
-    distance_simulation_input::DistanceSimulationInput
+    distance_simulation_input::DistanceInput
     max_iter::Int64
 end
 

--- a/src/abc/model_selection_io.jl
+++ b/src/abc/model_selection_io.jl
@@ -6,7 +6,7 @@ struct SimulatedModelSelectionInput{AF<:AbstractFloat, CUD<:ContinuousUnivariate
 	threshold_schedule::AbstractArray{AF,1}
 	model_prior::DiscreteUnivariateDistribution
 	parameter_priors::AbstractArray{Array{CUD, 1},1}
-	distance_simulation_input::AbstractArray{DistanceSimulationInput,1}
+	distance_simulation_input::AbstractArray{<:DistanceInput,1}
 	max_iter::Int
 end
 

--- a/src/util/emulation_helpers.jl
+++ b/src/util/emulation_helpers.jl
@@ -1,6 +1,6 @@
 # not exported
 function simulate_distance(parameters::AbstractArray{Float64, 2},
-        distance_simulation_input::DistanceSimulationInput)
+        distance_simulation_input::DistanceInput)
     n_design_points = size(parameters, 1)
     y = zeros(n_design_points)
     for i in 1:n_design_points

--- a/src/util/emulation_helpers.jl
+++ b/src/util/emulation_helpers.jl
@@ -19,8 +19,9 @@ function abc_train_emulator(priors::AbstractArray{CUD}, training_input::Emulator
     X = zeros(training_input.design_points, n_dims)
     X .= rand.(priors)
     y = simulate_distance(X, training_input.distance_simulation_input)
-    train_emulator(X, reshape(y, (length(y), 1)), training_input.emulator_training)
+    emulator = train_emulator(X, reshape(y, (length(y), 1)), training_input.emulator_training)
     @debug "Emulator trained"
+    return emulator
 end
 
 """

--- a/src/util/emulation_helpers.jl
+++ b/src/util/emulation_helpers.jl
@@ -20,6 +20,7 @@ function abc_train_emulator(priors::AbstractArray{CUD}, training_input::Emulator
     X .= rand.(priors)
     y = simulate_distance(X, training_input.distance_simulation_input)
     train_emulator(X, reshape(y, (length(y), 1)), training_input.emulator_training)
+    @debug "Emulator trained"
 end
 
 """


### PR DESCRIPTION
At the moment, `DistanceSimulationInput` requires `reference_summary_statistic` to be a 1 dimensional array of `Float64`, however the are some cases where that may not be the case. As such, I created a `DistanceInput` abstract type which is now the parent of `DistanceSimulationInput`. This allows users to create their own `DistanceSimulationInput` equivalent with a different type signature for `reference_summary_statistic`