### PR TITLE
fix inverted normalise calculation for AbstractArray weights

### DIFF
--- a/src/abc/smc.jl
+++ b/src/abc/smc.jl
@@ -104,7 +104,7 @@ function normalise(
 end
 
 function normalise(weight_values::AbstractArray{F, 1}, tosum = 1.0) where F<:AbstractFloat
-    return StatsBase.Weights(weight_values .* (sum(weight_values) / tosum), tosum)
+    return StatsBase.Weights(weight_values .* (tosum / sum(weight_values)), tosum)
 end
 
 #


### PR DESCRIPTION
The normalise() method for AbstractArray weight_values (line 106) appears to have inverted the normalisation formula in comparison to the method for AbstractWeights (line 96), but they should probably be the same.